### PR TITLE
Update order.go

### DIFF
--- a/order.go
+++ b/order.go
@@ -338,7 +338,7 @@ func NewLimitOrder(action string, lmtPrice float64, quantity float64) *Order {
 
 func NewMarketOrder(action string, quantity float64) *Order {
 	o := NewOrder()
-	o.OrderType = "LMT"
+	o.OrderType = "MKT"
 	o.Action = action
 	o.TotalQuantity = quantity
 


### PR DESCRIPTION
orderType should be "MKT" for market orders
does order API work ? 
secType and conID are required with CP web gateway.