### PR TITLE
handle an empty LastTradetime

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -961,11 +961,12 @@ func (d *ibDecoder) processContractDataMsg(msgBuf *MsgBuffer) {
 	lastTradeDateOrContractMonth := msgBuf.readString()
 	if lastTradeDateOrContractMonth != "" {
 		splitted := strings.Split(lastTradeDateOrContractMonth, " ")
-		switch l := len(splitted); {
-		case l > 0:
+		l := len(splitted)
+
+		if l > 0 {
 			cd.Contract.Expiry = splitted[0]
-			fallthrough
-		case l > 1:
+		}
+		if l > 1 {
 			cd.LastTradeTime = splitted[1]
 		}
 	}


### PR DESCRIPTION
If you request contract details in a way that returns expired option contracts (eg, no expiration date), `lastTradeDateOrContractMonth` contains no `LastTradeTime`:

```
2021-01-27T07:48:36.038-0500    error   ibapi@v0.0.0-20201217142230-d33eaa86c485/client.go:2938 decoder got unexpected error    {"error": "runtime error: index out of range [1] with length 1"}
github.com/hadrianl/ibapi.(*IbClient).goDecode.func1
        github.com/hadrianl/ibapi@v0.0.0-20201217142230-d33eaa86c485/client.go:2938
runtime.gopanic
        runtime/panic.go:969
runtime.goPanicIndex
        runtime/panic.go:88
github.com/hadrianl/ibapi.(*ibDecoder).processContractDataMsg
        github.com/hadrianl/ibapi@v0.0.0-20201217142230-d33eaa86c485/decoder.go:972
github.com/hadrianl/ibapi.(*ibDecoder).interpret
        github.com/hadrianl/ibapi@v0.0.0-20201217142230-d33eaa86c485/decoder.go:51
github.com/hadrianl/ibapi.(*IbClient).goDecode
        github.com/hadrianl/ibapi@v0.0.0-20201217142230-d33eaa86c485/client.go:2954
2021-01-27T07:48:36.038-0500    info    ibapi@v0.0.0-20201217142230-d33eaa86c485/client.go:2941 try to restart decoder
```

This PR reworks the logic to handle that case.